### PR TITLE
Generic/SLURM queue variable

### DIFF
--- a/propr.sh
+++ b/propr.sh
@@ -56,12 +56,13 @@ getHoldIds() {
 			fi
 		done
 	fi
-	
+
 	echo $HOLDFOR
 }
 
 # Stub values to work with
 SCHEDULER='dry'
+QUEUE='defq'
 SGE_PE='singlenode'
 DIR_NODES=$DIR_BASE/pipelines/
 ARG_SUBBASE=""

--- a/submit/slurm.sh
+++ b/submit/slurm.sh
@@ -9,7 +9,7 @@ submit() {
 		then
 			SUBARGS="$SUBARGS -c $(($AVAL<$ARG_JOB_CPU_MAX?$AVAL:$ARG_JOB_CPU_MAX))"
 		fi
-		
+
 		if [ $ANAME = "array" ]
 		then
 			SUBARGS="$SUBARGS -a ${AVAL//,/:}"
@@ -27,6 +27,7 @@ submit() {
 
 	# Submit to SLURM
 	JOBID=`sbatch \
+        --partition ${QUEUE} \
 		$HOLDFOR \
 		-J $JOB_NAME \
 		-e $FILE_LOG_ERR \
@@ -34,7 +35,7 @@ submit() {
 		$SUBARGS \
 		$NODE \
 		$ADDS`
-	
+
 	# Fix the JobID
 	JOBID=`echo $JOBID | cut -d\  -f4`
 }


### PR DESCRIPTION
Added support for choosing a differrent queue when starting RoStr. Currently, the "QUEUE" variable is only  utilized with the SLURM scheduler, but it could be expanded to other schedulers present in the framework.

Also, jo Roy!